### PR TITLE
Add support for TextMate 2

### DIFF
--- a/manifests/textmate2.pp
+++ b/manifests/textmate2.pp
@@ -1,0 +1,10 @@
+# Public: Install TextMate 2.app into /Applications.
+#
+# Examples
+#
+#   include textmate::textmate2
+class textmate::textmate2 inherits textmate {
+  package ['TextMate'] {
+    source   => 'https://github.com/downloads/textmate/textmate/TextMate_r9383.tbz',
+  }
+}


### PR DESCRIPTION
Unfortunately, the [URL](https://api.textmate.org/downloads/beta) for the latest TM2 prebuilt binary doesn't have a file extension on it, so we have to hard-code a specific release.

Also, I'm new to this whole Puppet thing, so any feedback would be appreciated.
