### PR TITLE
Support for Textmate 2 nightlies/beta/release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 ## Usage
 
+TextMate 1.5:
+
 ```puppet
 include textmate
+```
+
+TextMate 2:
+
+```puppet
+include textmate2::release  # normal release
+include textmate2::beta     # beta releases
+include textmate2::nightly  # nightly releases
 ```
 
 ## Required Puppet Modules

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,5 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/*/*_spec.rb'
 end
+
+task :default => :spec

--- a/manifests/textmate2.pp
+++ b/manifests/textmate2.pp
@@ -1,0 +1,2 @@
+class textmate::textmate2 {
+}

--- a/manifests/textmate2/beta.pp
+++ b/manifests/textmate2/beta.pp
@@ -1,0 +1,7 @@
+class textmate::textmate2::beta inherits textmate::textmate2 {
+  package { 'TextMate':
+    source   => 'https://api.textmate.org/downloads/beta',
+    provider => 'compressed_app',
+    flavor   => 'tbz'
+  }
+}

--- a/manifests/textmate2/nightly.pp
+++ b/manifests/textmate2/nightly.pp
@@ -1,0 +1,7 @@
+class textmate::textmate2::nightly inherits textmate::textmate2 {
+  package { 'TextMate':
+    source   => 'https://api.textmate.org/downloads/nightly',
+    provider => 'compressed_app',
+    flavor   => 'tbz'
+  }
+}

--- a/manifests/textmate2/release.pp
+++ b/manifests/textmate2/release.pp
@@ -1,0 +1,7 @@
+class textmate::textmate2::release inherits textmate::textmate2 {
+  package { 'TextMate':
+    source   => 'https://api.textmate.org/downloads/release',
+    provider => 'compressed_app',
+    flavor   => 'tbz'
+  }
+}

--- a/spec/classes/textmate2_spec.rb
+++ b/spec/classes/textmate2_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'textmate::textmate2::release' do
+  it do
+    should contain_package('TextMate').with({
+      :source   => 'https://api.textmate.org/downloads/release',
+      :provider => 'compressed_app',
+      :flavor   => 'tbz'
+    })
+  end
+end
+
+describe 'textmate::textmate2::beta' do
+  it do
+    should contain_package('TextMate').with({
+      :source   => 'https://api.textmate.org/downloads/beta',
+      :provider => 'compressed_app',
+      :flavor   => 'tbz'
+    })
+  end
+end
+
+describe 'textmate::textmate2::nightly' do
+  it do
+    should contain_package('TextMate').with({
+      :source   => 'https://api.textmate.org/downloads/nightly',
+      :provider => 'compressed_app',
+      :flavor   => 'tbz'
+    })
+  end
+end
+

--- a/spec/classes/textmate_spec.rb
+++ b/spec/classes/textmate_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 describe 'textmate' do
-  let(:facts) do
-    {
-      :boxen_home => '/opt/boxen'
-    }
-  end
-
   it do
     should contain_package('TextMate').with({
       :source   => 'http://download.macromates.com/TextMate_1.5.11_r1635.zip',


### PR DESCRIPTION
This uses the `:flavor` idea from #1 in order to provide support for Textmate 2 release, beta and nighties.

It worked fine on my machine on the initial run, but I couldn't find out how to actually remove the package to re-test the other versions (`ensure => absent` didn't do the trick). 
