### PR TITLE
Fix TextMate 2 class names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ include textmate
 TextMate 2:
 
 ```puppet
-include textmate2::release  # normal release
-include textmate2::beta     # beta releases
-include textmate2::nightly  # nightly releases
+include textmate::textmate2::release  # normal release
+include textmate::textmate2::beta     # beta releases
+include textmate::textmate2::nightly  # nightly releases
 ```
 
 ## Required Puppet Modules


### PR DESCRIPTION
Unless I was doing something wrong, you need the `textmate` prefix on these.
